### PR TITLE
Persist clamped custom island position after window resize

### DIFF
--- a/time-island-v4.user.js
+++ b/time-island-v4.user.js
@@ -621,6 +621,8 @@
       const y=Math.max(0,Math.min(cfg.islandPosY,window.innerHeight-r.height));
       island.style.left=x+'px'; island.style.top=y+'px';
       island.style.right='auto'; island.style.bottom='auto'; island.style.transform='none';
+      if(x!==cfg.islandPosX){ cfg.islandPosX=x; gSet('ti_posX',x); }
+      if(y!==cfg.islandPosY){ cfg.islandPosY=y; gSet('ti_posY',y); }
     }else{
       // Preset: clear inline coords so the CSS class can drive positioning.
       island.style.left=''; island.style.top='';


### PR DESCRIPTION
## Summary
- When the island is in custom drag mode, `syncIslandClasses()` clamps the rendered coordinates to keep the island visible after a window resize, but the stored `cfg.islandPosX/Y` (and the `ti_posX` / `ti_posY` GM values) were left at the old, possibly off-screen values.
- This caused two problems: a brief visible jump on next load (island painted at the old coords before being re-clamped), and a persistent off-screen state when moving to a smaller display.
- Fix: after clamping inside `syncIslandClasses`, write the clamped `x` / `y` back to `cfg` and `GM` storage when they differ from the stored values, so the saved position stays in sync with what's actually rendered.

## Test plan
- [ ] Drag island near the right/bottom edge of a wide window, then shrink the window so the original coords fall outside the viewport.
- [ ] Reload the script and confirm the island appears at the clamped (in-viewport) position with no brief jump.
- [ ] Verify dragging still saves coordinates as before (no regression in normal drag persistence).
- [ ] Switch back to a larger viewport and confirm the island stays at the clamped coords (it should not re-expand to old off-screen values).

https://claude.ai/code/session_019mVy8JWaefmHon8yUZqqUY

---
_Generated by [Claude Code](https://claude.ai/code/session_019mVy8JWaefmHon8yUZqqUY)_